### PR TITLE
Authenticate with the instance password again

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 ## [Unreleased]
 
+- Authenticate with the instance password again instead of requesting an
+  access token first. Backends with two-factor authentication challenge the
+  token endpoint and the gem couldn't complete the login. The order endpoints
+  are never challenged and the password works on all of them.
+- Add an `access_token` option to `Taler::Client` and `Taler::Order` for
+  callers who don't want to share the instance password.
+- Check the response status of all requests and raise `Taler::RequestError`
+  instead of failing to parse an unexpected body.
+- Raise `Taler::ChallengeRequired` when the backend asks for two-factor
+  authentication.
+- `Taler::Client#request_token` takes a `scope` and a `duration` and reads the
+  `access_token` field, falling back to the deprecated `token` field.
+
 ## [0.3.0] - 2026-02-24
 
 - Update docs and rbs file.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ bundle add taler
 require "taler"
 
 backend_url = "https://backend.demo.taler.net/instances/sandbox"
-backend_password = "sandbox"
+password = "sandbox"
 
 order = Taler::Order.new(backend_url:, password:)
 order.create(
@@ -42,6 +42,39 @@ end
 Read more in the official documentation:
 
 - https://rubydoc.info/gems/taler
+
+## Authentication
+
+By default, all requests authenticate with the instance password. That is
+deprecated since merchant API v19 but it is the only method that works
+unattended on every endpoint.
+
+Alternatively, you can pass an access token obtained elsewhere, for example
+from the merchant backoffice, and keep the password to yourself:
+
+```rb
+order = Taler::Order.new(backend_url:, access_token: "secret-token:...")
+```
+
+`Taler::Client#request_token` can obtain such a token, optionally limited in
+scope and duration:
+
+```rb
+client = Taler::Client.new(backend_url, password)
+client.request_token(scope: "order-mgmt:refreshable")
+```
+
+Note that the backend may require two-factor authentication for that endpoint.
+It then answers with a list of challenges to solve and this gem raises
+`Taler::ChallengeRequired`. Solving challenges needs a person to enter a TAN
+and isn't supported yet. Since the order endpoints are never challenged,
+password authentication keeps working on such a backend.
+
+## Errors
+
+All requests raise `Taler::RequestError` when the backend responds with an
+unexpected status code. The error carries the `status` and the raw `body` of
+the response.
 
 ## Development
 

--- a/lib/taler.rb
+++ b/lib/taler.rb
@@ -8,4 +8,56 @@ require_relative "taler/version"
 module Taler
   # Base error class for errors raised in this module
   class Error < StandardError; end
+
+  # Raised when the merchant backend answers with an unexpected status code.
+  class RequestError < Error
+    # @return [Integer] The HTTP status code of the response.
+    attr_reader :status
+
+    # @return [String] The raw response body.
+    attr_reader :body
+
+    # @param message [String]
+    # @param status [Integer]
+    # @param body [String]
+    def initialize(message, status:, body:)
+      super(message)
+      @status = status
+      @body = body
+    end
+  end
+
+  # Raised when the backend wants multi-factor authentication before it
+  # performs the requested operation.
+  #
+  # The backend answers with `202 Accepted` and a list of challenges. Each
+  # challenge has to be requested and then solved with a TAN sent to the
+  # instance owner. Solving challenges is not supported by this gem yet.
+  #
+  # Only account management endpoints require MFA. Most notably, requesting
+  # an access token may be challenged while the order endpoints never are.
+  # So you can avoid this error by authenticating with the instance password
+  # instead of an access token, which is the default.
+  #
+  # See: https://docs.taler.net/core/api-merchant.html#two-factor-auth
+  class ChallengeRequired < RequestError
+    # @return [Array<Hash>] The challenges to solve. Each one has a
+    #   `challenge_id`, a `tan_channel` and a `tan_info` hint.
+    attr_reader :challenges
+
+    # @return [Boolean] True if *all* challenges have to be solved, false if
+    #   it is sufficient to solve one of them.
+    attr_reader :combi_and
+
+    # @param message [String]
+    # @param status [Integer]
+    # @param body [String]
+    # @param challenges [Array<Hash>]
+    # @param combi_and [Boolean]
+    def initialize(message, status:, body:, challenges: [], combi_and: false)
+      super(message, status:, body:)
+      @challenges = challenges
+      @combi_and = combi_and
+    end
+  end
 end

--- a/lib/taler/client.rb
+++ b/lib/taler/client.rb
@@ -9,20 +9,51 @@ module Taler
   # See: https://docs.taler.net/core/api-merchant.html
   class Client
     # @param backend_url [String] e.g. `"https://backend.demo.taler.net/instances/sandbox"`
-    # @param password [String]
-    def initialize(backend_url, password)
+    # @param password [String, nil] The instance password. It is used as
+    #   authentication token for all requests unless an `access_token` is
+    #   given.
+    # @param access_token [String, nil] A token obtained from the
+    #   `/private/token` endpoint, see {#request_token}. It has to include the
+    #   `"secret-token:"` prefix. Given a token, the password isn't needed.
+    # @raise [ArgumentError] If neither password nor access token are given.
+    def initialize(backend_url, password = nil, access_token: nil)
+      if password.nil? && access_token.nil?
+        raise ArgumentError, "Provide a password or an access_token."
+      end
+
       @backend_url = backend_url
       @password = password
+      @access_token = access_token
     end
 
-    # Obtain an access token to authenticate all other API calls.
+    # Obtain an access token to authenticate other API calls.
     #
-    # @return [String]
-    def request_token
+    # This is optional. All requests authenticate with the instance password
+    # by default. But an access token can be scoped and passed on to a less
+    # trusted party without sharing the instance password.
+    #
+    # Beware that the backend may require multi-factor authentication for
+    # this endpoint. It then answers with a list of challenges to solve and
+    # this method raises {ChallengeRequired}. The order endpoints are never
+    # challenged, so password authentication keeps working in that case.
+    #
+    # @param scope [String] Which kinds of operations the token allows, e.g.
+    #   `"order-mgmt"` to create, read and refund orders. Tokens of the
+    #   default `"all"` scope are always refreshable.
+    # @param duration [Hash, nil] How long the token stays valid, e.g.
+    #   `{d_us: 86_400_000_000}` for one day. The backend applies its own
+    #   upper bound and its own default when this is omitted.
+    # @return [String] The token including the `"secret-token:"` prefix.
+    # @raise [ChallengeRequired] If the backend requires MFA.
+    # @raise [RequestError] If the backend rejects the request.
+    def request_token(scope: "all", duration: nil)
       url = "#{@backend_url}/private/token"
-      payload = {scope: "write"}
-      result = request(url, token: auth_token, payload:)
-      result.fetch("token")
+      payload = {scope:}
+      payload[:duration] = duration unless duration.nil?
+      result = request(url, token: password_token, payload:)
+
+      # The `token` field is deprecated since merchant API v19.
+      result["access_token"] || result.fetch("token")
     end
 
     # @param amount [String] e.g. "KUDOS:200"
@@ -33,6 +64,7 @@ module Taler
     #   payment.
     # @return [Hash] The resonse from the backend, usually just containing an
     #   order id, e.g. `{order_id: "xxxxx"}`
+    # @raise [RequestError] If the backend rejects the request.
     def create_order(amount:, summary:, fulfillment_url: nil, fulfillment_message: nil)
       url = "#{@backend_url}/private/orders"
       order = {
@@ -53,6 +85,7 @@ module Taler
 
     # @param order_id [String]
     # @return [Hash] The order status returned by the backend.
+    # @raise [RequestError] If the backend rejects the request.
     def fetch_order(order_id)
       url = "#{@backend_url}/private/orders/#{order_id}"
       request(url)
@@ -63,6 +96,7 @@ module Taler
     # @param reason [String] Why are you refunding?
     #
     # @return [Hash] Response from the merchant backend.
+    # @raise [RequestError] If the backend rejects the request.
     def refund_order(order_id, refund:, reason:)
       url = "#{@backend_url}/private/orders/#{order_id}/refund"
       payload = {refund:, reason:}
@@ -71,38 +105,108 @@ module Taler
 
     private
 
+    # The instance password in the format of an authentication token.
+    #
+    # This is deprecated since merchant API v19 but still the simplest way to
+    # authenticate. It works on all endpoints and is never challenged for
+    # multi-factor authentication.
+    #
     # @return [String]
-    def auth_token
+    def password_token
       "secret-token:#{@password}"
     end
 
     # @return [String]
-    def access_token
-      @access_token ||= request_token
+    def auth_token
+      @access_token || password_token
     end
 
     # @param url [String]
     # @param token [String]
-    # @param payload [Hash]
-    # @return [String]
-    def request(url, token: access_token, payload: nil)
+    # @param payload [Hash, nil] Sent as JSON body of a POST request. Without
+    #   a payload, a GET request is sent.
+    # @return [Hash] The parsed response body.
+    # @raise [ChallengeRequired] If the backend requires MFA.
+    # @raise [RequestError] If the backend answers with an error status.
+    def request(url, token: auth_token, payload: nil)
       uri = URI(url)
+      response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == "https") do |http|
+        http.request(build_request(uri, token, payload))
+      end
+
+      parse(response)
+    end
+
+    # @param uri [URI]
+    # @param token [String]
+    # @param payload [Hash, nil]
+    # @return [Net::HTTPRequest]
+    def build_request(uri, token, payload)
       headers = {
         "Authorization" => "Bearer #{token}",
         "Accept" => "application/json",
         "User-Agent" => "Taler Ruby"
       }
 
-      if payload.nil?
-        body = Net::HTTP.get(uri, headers)
-      else
-        headers["Content-Type"] = "application/json"
-        data = JSON.dump(payload)
-        response = Net::HTTP.post(uri, data, headers)
-        body = response.body
+      return Net::HTTP::Get.new(uri, headers) if payload.nil?
+
+      headers["Content-Type"] = "application/json"
+      Net::HTTP::Post.new(uri, headers).tap do |request|
+        request.body = JSON.dump(payload)
+      end
+    end
+
+    # @param response [Net::HTTPResponse]
+    # @return [Hash] The parsed response body.
+    # @raise [ChallengeRequired] If the backend requires MFA.
+    # @raise [RequestError] If the backend answers with an error status.
+    def parse(response)
+      status = response.code.to_i
+      body = response.body.to_s
+
+      # A 202 is a success status but it doesn't contain what we asked for.
+      raise challenge_error(status, body) if status == 202
+
+      unless response.is_a?(Net::HTTPSuccess)
+        raise RequestError.new(
+          "The Taler backend responded with #{status}: #{summarise(body)}",
+          status:, body:
+        )
       end
 
       JSON.parse(body)
+    end
+
+    # @param status [Integer]
+    # @param body [String]
+    # @return [ChallengeRequired]
+    def challenge_error(status, body)
+      challenge = begin
+        JSON.parse(body)
+      rescue JSON::ParserError
+        {}
+      end
+      challenges = challenge["challenges"] || []
+      channels = challenges.filter_map { |c| c["tan_channel"] }.join(", ")
+
+      ChallengeRequired.new(
+        "The Taler backend requires multi-factor authentication" \
+        "#{" via #{channels}" unless channels.empty?}. " \
+        "Solving challenges is not supported. " \
+        "Authenticate with the instance password instead of an access token.",
+        status:,
+        body:,
+        challenges:,
+        combi_and: challenge["combi_and"] || false
+      )
+    end
+
+    # Error bodies can be long, especially when a proxy returns HTML.
+    #
+    # @param body [String]
+    # @return [String]
+    def summarise(body)
+      (body.length > 500) ? "#{body[0, 500]}..." : body
     end
   end
 end

--- a/lib/taler/order.rb
+++ b/lib/taler/order.rb
@@ -6,15 +6,18 @@ module Taler
     # Connect an Order to the Taler merchant backend.
     #
     # @param backend_url [String] e.g. `"https://backend.demo.taler.net/instances/sandbox"`
-    # @param password [String] e.g. `"sandbox"`
+    # @param password [String, nil] e.g. `"sandbox"`
+    # @param access_token [String, nil] An alternative to the password, see
+    #   {Client#request_token}. It has to include the `"secret-token:"` prefix.
     # @param id [String] The order id of an existing order.
+    # @raise [ArgumentError] If neither password nor access token are given.
     # @example Connect to the official demo backend
     #   Taler::Order.new(
     #     backend_url: "https://backend.demo.taler.net/instances/sandbox",
     #     password: "sandbox"
     #   )
-    def initialize(backend_url:, password:, id: nil)
-      @client = Client.new(backend_url, password)
+    def initialize(backend_url:, password: nil, access_token: nil, id: nil)
+      @client = Client.new(backend_url, password, access_token:)
       @id = id
     end
 

--- a/sig/taler.rbs
+++ b/sig/taler.rbs
@@ -6,6 +6,62 @@ module Taler
   class Error < StandardError
   end
 
+  # Raised when the merchant backend answers with an unexpected status code.
+  class RequestError < Taler::Error
+    # _@param_ `message`
+    # 
+    # _@param_ `status`
+    # 
+    # _@param_ `body`
+    def initialize: (String message, status: Integer, body: String) -> void
+
+    # _@return_ — The HTTP status code of the response.
+    attr_reader status: Integer
+
+    # _@return_ — The raw response body.
+    attr_reader body: String
+  end
+
+  # Raised when the backend wants multi-factor authentication before it
+  # performs the requested operation.
+  # 
+  # The backend answers with `202 Accepted` and a list of challenges. Each
+  # challenge has to be requested and then solved with a TAN sent to the
+  # instance owner. Solving challenges is not supported by this gem yet.
+  # 
+  # Only account management endpoints require MFA. Most notably, requesting
+  # an access token may be challenged while the order endpoints never are.
+  # So you can avoid this error by authenticating with the instance password
+  # instead of an access token, which is the default.
+  # 
+  # See: https://docs.taler.net/core/api-merchant.html#two-factor-auth
+  class ChallengeRequired < Taler::RequestError
+    # _@param_ `message`
+    # 
+    # _@param_ `status`
+    # 
+    # _@param_ `body`
+    # 
+    # _@param_ `challenges`
+    # 
+    # _@param_ `combi_and`
+    def initialize: (
+                      String message,
+                      status: Integer,
+                      body: String,
+                      ?challenges: ::Array[::Hash[untyped, untyped]],
+                      ?combi_and: bool
+                    ) -> void
+
+    # _@return_ — The challenges to solve. Each one has a
+    # `challenge_id`, a `tan_channel` and a `tan_info` hint.
+    attr_reader challenges: ::Array[::Hash[untyped, untyped]]
+
+    # _@return_ — True if *all* challenges have to be solved, false if
+    # it is sufficient to solve one of them.
+    attr_reader combi_and: bool
+  end
+
   # Order representation with convenient access to the merchant API.
   class Order
     # Connect an Order to the Taler merchant backend.
@@ -13,6 +69,8 @@ module Taler
     # _@param_ `backend_url` — e.g. `"https://backend.demo.taler.net/instances/sandbox"`
     # 
     # _@param_ `password` — e.g. `"sandbox"`
+    # 
+    # _@param_ `access_token` — An alternative to the password, see {Client#request_token}. It has to include the `"secret-token:"` prefix.
     # 
     # _@param_ `id` — The order id of an existing order.
     # 
@@ -23,7 +81,12 @@ module Taler
     #   password: "sandbox"
     # )
     # ```
-    def initialize: (backend_url: String, password: String, ?id: String?) -> void
+    def initialize: (
+                      backend_url: String,
+                      ?password: String?,
+                      ?access_token: String?,
+                      ?id: String?
+                    ) -> void
 
     # Create a new order record ready to take a payment.
     # 
@@ -94,11 +157,28 @@ module Taler
   class Client
     # _@param_ `backend_url` — e.g. `"https://backend.demo.taler.net/instances/sandbox"`
     # 
-    # _@param_ `password`
-    def initialize: (String backend_url, String password) -> void
+    # _@param_ `password` — The instance password. It is used as authentication token for all requests unless an `access_token` is given.
+    # 
+    # _@param_ `access_token` — A token obtained from the `/private/token` endpoint, see {#request_token}. It has to include the `"secret-token:"` prefix. Given a token, the password isn't needed.
+    def initialize: (String backend_url, ?String? password, ?access_token: String?) -> void
 
-    # Obtain an access token to authenticate all other API calls.
-    def request_token: () -> String
+    # Obtain an access token to authenticate other API calls.
+    # 
+    # This is optional. All requests authenticate with the instance password
+    # by default. But an access token can be scoped and passed on to a less
+    # trusted party without sharing the instance password.
+    # 
+    # Beware that the backend may require multi-factor authentication for
+    # this endpoint. It then answers with a list of challenges to solve and
+    # this method raises {ChallengeRequired}. The order endpoints are never
+    # challenged, so password authentication keeps working in that case.
+    # 
+    # _@param_ `scope` — Which kinds of operations the token allows, e.g. `"order-mgmt"` to create, read and refund orders. Tokens of the default `"all"` scope are always refreshable.
+    # 
+    # _@param_ `duration` — How long the token stays valid, e.g. `{d_us: 86_400_000_000}` for one day. The backend applies its own upper bound and its own default when this is omitted.
+    # 
+    # _@return_ — The token including the `"secret-token:"` prefix.
+    def request_token: (?scope: String, ?duration: ::Hash[untyped, untyped]?) -> String
 
     # _@param_ `amount` — e.g. "KUDOS:200"
     # 
@@ -134,15 +214,47 @@ module Taler
     # _@return_ — Response from the merchant backend.
     def refund_order: (String order_id, refund: String, reason: String) -> ::Hash[untyped, untyped]
 
-    def auth_token: () -> String
+    # The instance password in the format of an authentication token.
+    # 
+    # This is deprecated since merchant API v19 but still the simplest way to
+    # authenticate. It works on all endpoints and is never challenged for
+    # multi-factor authentication.
+    def password_token: () -> String
 
-    def access_token: () -> String
+    def auth_token: () -> String
 
     # _@param_ `url`
     # 
     # _@param_ `token`
     # 
+    # _@param_ `payload` — Sent as JSON body of a POST request. Without a payload, a GET request is sent.
+    # 
+    # _@return_ — The parsed response body.
+    def request: (String url, ?token: String, ?payload: ::Hash[untyped, untyped]?) -> ::Hash[untyped, untyped]
+
+    # sord warn - URI wasn't able to be resolved to a constant in this project
+    # sord warn - Net::HTTPRequest wasn't able to be resolved to a constant in this project
+    # _@param_ `uri`
+    # 
+    # _@param_ `token`
+    # 
     # _@param_ `payload`
-    def request: (String url, ?token: String, ?payload: ::Hash[untyped, untyped]?) -> String
+    def build_request: (URI uri, String token, ::Hash[untyped, untyped]? payload) -> Net::HTTPRequest
+
+    # sord warn - Net::HTTPResponse wasn't able to be resolved to a constant in this project
+    # _@param_ `response`
+    # 
+    # _@return_ — The parsed response body.
+    def parse: (Net::HTTPResponse response) -> ::Hash[untyped, untyped]
+
+    # _@param_ `status`
+    # 
+    # _@param_ `body`
+    def challenge_error: (Integer status, String body) -> ChallengeRequired
+
+    # Error bodies can be long, especially when a proxy returns HTML.
+    # 
+    # _@param_ `body`
+    def summarise: (String body) -> String
   end
 end

--- a/spec/taler/client_spec.rb
+++ b/spec/taler/client_spec.rb
@@ -43,4 +43,126 @@ RSpec.describe Taler::Client do
     expect(order).to include("order_status" => "paid")
     expect(order).to include("refunded" => true)
   end
+
+  describe "authentication" do
+    let(:orders_url) { "#{backend_url}/private/orders" }
+
+    it "requires a password or an access token" do
+      expect { Taler::Client.new(backend_url) }
+        .to raise_error(ArgumentError, /password or an access_token/)
+    end
+
+    it "authenticates with the instance password by default" do
+      request = stub_request(:post, orders_url)
+        .with(headers: {"Authorization" => "Bearer secret-token:sandbox"})
+        .to_return(body: {order_id: "one"}.to_json)
+
+      client.create_order(amount: "KUDOS:1", summary: "Order total")
+
+      expect(request).to have_been_requested
+    end
+
+    it "doesn't request an access token" do
+      token_request = stub_request(:post, "#{backend_url}/private/token")
+      stub_request(:post, orders_url).to_return(body: {order_id: "one"}.to_json)
+
+      client.create_order(amount: "KUDOS:1", summary: "Order total")
+
+      expect(token_request).not_to have_been_requested
+    end
+
+    it "authenticates with a given access token" do
+      client = Taler::Client.new(backend_url, access_token: "secret-token:abc")
+      request = stub_request(:post, orders_url)
+        .with(headers: {"Authorization" => "Bearer secret-token:abc"})
+        .to_return(body: {order_id: "one"}.to_json)
+
+      client.create_order(amount: "KUDOS:1", summary: "Order total")
+
+      expect(request).to have_been_requested
+    end
+
+    it "prefers the access token of a token request over the deprecated one" do
+      stub_request(:post, "#{backend_url}/private/token")
+        .to_return(body: {token: "secret-token:old", access_token: "secret-token:new"}.to_json)
+
+      expect(client.request_token).to eq "secret-token:new"
+    end
+
+    it "falls back to the deprecated token field" do
+      stub_request(:post, "#{backend_url}/private/token")
+        .to_return(body: {token: "secret-token:old"}.to_json)
+
+      expect(client.request_token).to eq "secret-token:old"
+    end
+  end
+
+  describe "error handling" do
+    let(:order_url) { "#{backend_url}/private/orders/one" }
+
+    it "raises an error when the backend rejects the request" do
+      stub_request(:get, order_url).to_return(status: 401, body: "Unauthorized")
+
+      expect { client.fetch_order("one") }.to raise_error(Taler::RequestError) { |error|
+        expect(error.message).to include "401"
+        expect(error.message).to include "Unauthorized"
+        expect(error.status).to eq 401
+        expect(error.body).to eq "Unauthorized"
+      }
+    end
+
+    it "raises an error when the backend fails" do
+      stub_request(:get, order_url).to_return(status: 500, body: "<html>Oops</html>")
+
+      expect { client.fetch_order("one") }
+        .to raise_error(Taler::RequestError, /500/)
+    end
+
+    it "truncates long error bodies" do
+      stub_request(:get, order_url).to_return(status: 502, body: "x" * 900)
+
+      expect { client.fetch_order("one") }.to raise_error(Taler::RequestError) { |error|
+        expect(error.message).to end_with "..."
+        expect(error.message.length).to be < 600
+        expect(error.body.length).to eq 900
+      }
+    end
+
+    it "raises a challenge error when the backend requires MFA" do
+      challenge = {
+        challenges: [
+          {challenge_id: "one", tan_channel: "email", tan_info: "m...@example.com"},
+          {challenge_id: "two", tan_channel: "sms", tan_info: "+61...789"}
+        ],
+        combi_and: false
+      }
+      stub_request(:post, "#{backend_url}/private/token")
+        .to_return(status: 202, body: challenge.to_json)
+
+      expect { client.request_token }.to raise_error(Taler::ChallengeRequired) { |error|
+        expect(error.message).to include "multi-factor authentication via email, sms"
+        expect(error.message).to include "instance password"
+        expect(error.status).to eq 202
+        expect(error.challenges.map { |c| c["challenge_id"] }).to eq %w[one two]
+        expect(error.combi_and).to be false
+      }
+    end
+
+    it "raises a challenge error even without a readable body" do
+      stub_request(:post, "#{backend_url}/private/token")
+        .to_return(status: 202, body: "<html>Accepted</html>")
+
+      expect { client.request_token }.to raise_error(Taler::ChallengeRequired) { |error|
+        expect(error.challenges).to eq []
+        expect(error.combi_and).to be false
+      }
+    end
+
+    it "raises a challenge error that can be rescued as a request error" do
+      stub_request(:post, "#{backend_url}/private/token")
+        .to_return(status: 202, body: "{}")
+
+      expect { client.request_token }.to raise_error(Taler::RequestError)
+    end
+  end
 end

--- a/spec/taler/order_spec.rb
+++ b/spec/taler/order_spec.rb
@@ -35,4 +35,19 @@ RSpec.describe Taler::Order do
     expect(order.inspect).to match(/"refunded" ?=> ?true/)
     expect(order.inspect).to match(/"refund_amount" ?=> ?"KUDOS:4"/)
   end
+
+  it "can authenticate with an access token instead of a password" do
+    order = Taler::Order.new(backend_url:, access_token: "secret-token:abc")
+    request = stub_request(:post, "#{backend_url}/private/orders")
+      .with(headers: {"Authorization" => "Bearer secret-token:abc"})
+      .to_return(body: {order_id: "one"}.to_json)
+
+    expect(order.create(amount: "KUDOS:4", summary: "Order total")).to eq "one"
+    expect(request).to have_been_requested
+  end
+
+  it "requires a password or an access token" do
+    expect { Taler::Order.new(backend_url:) }
+      .to raise_error(ArgumentError, /password or an access_token/)
+  end
 end


### PR DESCRIPTION
Fixes the 500 that @mcmpp hit on a 2FA-enabled backend, reported in
openfoodfoundation/openfoodnetwork#14637.

## The bug

Since v0.3.0 every operation first calls `POST /private/token`. When the
backend has two-factor authentication enabled, that endpoint answers
`202 Accepted` with a list of challenges instead of a token:

```json
{"challenges": [{"tan_channel": "email", "challenge_id": "..."}], "combi_and": false}
```

`request` never looked at the status code, so we parsed that body and
`result.fetch("token")` raised a `KeyError`.

## Why not solve the challenges

Solving a challenge means sending a TAN to the instance owner and having a
person type it back. We can't do that while a customer is checking out.

We also don't have to. I went through the merchant API spec and only these
endpoints can return a 202 challenge:

`POST /instances` · `POST /instances/$I/forgot-password` · `POST /private/auth` ·
`POST /private/token` · `DELETE /private` · `POST /private/accounts` ·
`POST /private/donau`

The endpoints this gem uses — `POST /private/orders`,
`GET /private/orders/$ID` and `POST /private/orders/$ID/refund` — have no 202
in their documented responses. MFA gates account management and token
issuance, not order operations. And the spec is explicit that
`Authorization: Bearer secret-token:$INSTANCE_PASSWORD` reaches everything:
"Any API may be accessed using the bearer authentication".

So a 2FA-obtained token and the instance password grant identical capability
on every endpoint we call. Requesting the token bought us nothing and cost us
the ability to run unattended.

## What this does

- Authenticate with the instance password directly, as before v0.3.0. No
  token request. That also saves a round trip per operation and stops us
  minting a fresh token on every single call.
- Keep `request_token` and add an `access_token:` option to `Client` and
  `Order`, so callers who don't want to share the instance password can pass
  a token obtained elsewhere. `request_token` now takes `scope` and
  `duration`, and reads the `access_token` field with a fallback to the
  deprecated `token` field.
- Check the response status of every request. Raise `Taler::RequestError`
  carrying the status and body, and `Taler::ChallengeRequired` on a 202. This
  is the part I'd keep even if we went the other way: the old code turned
  every failure — 403, 500, an HTML error page from a proxy — into a confusing
  `KeyError` or `JSON::ParserError`, which is exactly what made this bug hard
  to read.

`Net::HTTP.get`/`.post` are replaced with `Net::HTTP.start` since the former
doesn't return a response object to inspect.

Password auth is `@deprecated since v19` and "will be phased out", but it is
still documented as functional in the current v21 spec and there is no removal
date. When it does go, `access_token:` is the hook to build the full TAN flow
on, and the storage half is already here.

## Testing

`bundle exec rake` is green — 21 examples, standard clean. The existing VCR
cassettes replay unchanged, which is itself a decent signal: the order
requests are identical apart from the `Authorization` header.

New specs cover password auth being the default, no token request being made,
the `access_token` option, both token response fields, and the error paths
including a 202 challenge with and without a parseable body.

I also smoke tested against the live demo backend. Creating and reading an
order with password auth:

```
created: 2026.226-GGXCJQ0000000
status: unpaid
```

And a deliberately wrong password now reports the backend's own explanation
instead of a `KeyError`:

```
Taler::RequestError: The Taler backend responded with 401: {
  "code": 2015,
  "hint": "The merchant refused the request due to lack of authorization.",
  "detail": "Check credentials in 'Authorization' header"
}
```

## Notes

No version bump — the README puts that in the release process. The
`CHANGELOG` entries are under `[Unreleased]`. `sig/taler.rbs` is regenerated
by `sord`.

OFN needs no change to consume this; `Spree::PaymentMethod::Taler` already
passes `password:`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)